### PR TITLE
Fixes for deprecation messages

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,12 +1,12 @@
 @import 'syntax-variables';
 
-atom-text-editor, :host {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
   line-height:1.4em;
   font-family: Menlo, Consolas, "Courier New", Courier, monospace;
 
-  .invisible-character {
+  .syntax--invisible-character {
     color: @syntax-invisible-character-color;
   }
 
@@ -43,102 +43,102 @@ atom-text-editor, :host {
     background-color: @syntax-selection-color;
   }
 
-  .search-results .marker .region {
+  .search-results .syntax--marker .region {
     background-color: transparent;
     border: 1px solid @syntax-result-marker-color;
   }
 
-  .search-results .marker.current-result .region {
+  .search-results .syntax--marker.current-result .region {
     border: 1px solid @syntax-result-marker-color-selected;
   }
 
-  .gfm {
-    .markup {
-      &.heading {
+  .syntax--gfm {
+    .syntax--markup {
+      &.syntax--heading {
         color: #A6E22E;
         font-weight: bold;
       }
 
-      &.underline {
+      &.syntax--underline {
         color: #E6DB74;
         text-decoration: underline;
       }
     }
 
-    .bold {
+    .syntax--bold {
       font-weight: bold;
     }
 
-    .italic {
+    .syntax--italic {
       font-style: italic;
     }
 
-    .raw {
+    .syntax--raw {
       color: #66D9EF;
     }
 
-    .variable.list {
+    .syntax--variable.syntax--list {
       color: #F92672;
       font-weight: bold;
     }
 
-    .link {
+    .syntax--link {
       color: #CCC;
 
-      .entity {
+      .syntax--entity {
         color: #AE81FF;
       }
     }
   }
 }
 
-.comment {
+.syntax--comment {
   color: #75715E;
 }
 
-.string {
+.syntax--string {
   color: #E6DB74;
 }
 
-.constant.numeric {
+.syntax--constant.syntax--numeric {
   color: #AE81FF;
 }
 
-.constant.language {
+.syntax--constant.syntax--language {
   color: #AE81FF;
 }
 
-.constant.character,
-.constant.escape,
-.constant.other {
+.syntax--constant.syntax--character,
+.syntax--constant.syntax--escape,
+.syntax--constant.syntax--other {
   color: #AE81FF;
 }
 
-.keyword {
+.syntax--keyword {
   color: #F92672;
 }
 
-.keyword.operator.bracket,
-.keyword.operator.punctuation,
+.syntax--keyword.syntax--operator.syntax--bracket,
+.syntax--keyword.syntax--operator.syntax--punctuation,
  {
   color: #FFFFFF;
 }
 
-.storage {
+.syntax--storage {
   color: #F92672;
 }
 
-.storage.type {
+.syntax--storage.syntax--type {
   font-style: italic;
   color: #66D9EF;
 }
 
-.entity.name.class {
+.syntax--entity.syntax--name.syntax--class {
   text-decoration: none;
   color: #A6E22E;
 }
 
-.entity.other.inherited-class {
+.syntax--entity.syntax--other.syntax--inherited-class {
   font-style: italic;
   text-decoration: none;
   color: #A6E22E;
@@ -150,61 +150,61 @@ atom-text-editor, :host {
   display: inline-block;
 }
 
-.entity.name.function {
+.syntax--entity.syntax--name.syntax--function {
   color: #A6E22E;
 }
 
-.entity.name.instance {
+.syntax--entity.syntax--name.syntax--instance {
   color: #66D9EF;
 }
 
-.variable.parameter {
+.syntax--variable.syntax--parameter {
   font-style: italic;
   color: #FD971F;
 }
 
-.entity.name.tag {
+.syntax--entity.syntax--name.syntax--tag {
   color: #F92672;
 }
 
-.entity.other.attribute-name {
+.syntax--entity.syntax--other.syntax--attribute-name {
   color: #A6E22E;
 }
 
-.support.function {
+.syntax--support.syntax--function {
   color: #66D9EF;
 }
 
-.support.function.decl {
+.syntax--support.syntax--function.syntax--decl {
   color: #A6E22E;
 }
 
-.support.constant {
+.syntax--support.syntax--constant {
   color: #66D9EF;
 }
 
-.support.type,
-.support.class {
+.syntax--support.syntax--type,
+.syntax--support.syntax--class {
   font-style: italic;
   color: #66D9EF;
 }
 
-.invalid {
+.syntax--invalid {
   color: #F8F8F0;
   background-color: #F92672;
 }
 
-.invalid.deprecated {
+.syntax--invalid.syntax--deprecated {
   color: #F8F8F0;
   background-color: #AE81FF;
 }
 
 // Jade syntax
-.class.jade {
+.syntax--class.syntax--jade {
   color: #AE81FF;
 }
 
 // 'this' Javascript
-.variable.language.js {
+.syntax--variable.syntax--language.syntax--js {
   color: #F92672;
 }


### PR DESCRIPTION
Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. 